### PR TITLE
Patch item matches for the new IMDB site design

### DIFF
--- a/src/HtmlPieces.php
+++ b/src/HtmlPieces.php
@@ -34,8 +34,18 @@ class HtmlPieces
                 break;
 
             case "year":
-                $patterns = ["section section div div div ul li a", ".title_wrapper h1 #titleYear a"];
+                $patterns = ["section section div div div ul li a", ".title_wrapper h1 #titleYear a", ".title_wrapper .subtext a[title='See more release dates']"];
                 $year = $this->findMatchInPatterns($dom, $page, $patterns);
+
+                // Detect OLD IMDB + TV show
+                if ($this->count($year) > 4) {
+                    // Extract year from text
+                    // \d{4}.\d{4}
+                    $matchYear = preg_replace("/[^\d{4}-–\d{4}]/", "", $year);
+                    if ($this->count($matchYear) > 0) {
+                        $year = $matchYear;
+                    }
+                }
 
                 return $this->strClean($year);
                 break;

--- a/src/HtmlPieces.php
+++ b/src/HtmlPieces.php
@@ -77,7 +77,7 @@ class HtmlPieces
                 break;
 
             case "rating":
-                $patterns = ["main div[data-testid=hero-title-block__aggregate-rating__score]", ".ratings_wrapper .ratingValue span[itemprop=ratingValue]"];
+                $patterns = ["main div[data-testid=hero-title-block__aggregate-rating__score] span", ".ratings_wrapper .ratingValue span[itemprop=ratingValue]"];
                 $rating = $this->findMatchInPatterns($dom, $page, $patterns);
 
                 return $this->strClean($rating);

--- a/src/HtmlPieces.php
+++ b/src/HtmlPieces.php
@@ -27,7 +27,15 @@ class HtmlPieces
 
         switch ($element) {
             case "title":
-                $title = $dom->find($page, 'h1[data-testid=hero-title-block__title]')->text;
+                $patterns = [".title_wrapper h1", "h1[data-testid=hero-title-block__title]"];
+                $title = "";
+
+                foreach ($patterns as $pattern)
+                {
+                    $title = $dom->find($page, $pattern)->text;
+                    if ($this->count($title) > 0) break;
+                }
+
                 return $this->strClean($title);
                 break;
 

--- a/tests/HtmlPiecesTest.php
+++ b/tests/HtmlPiecesTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use hmerritt\HtmlPieces;
+
+class HtmlPiecesTest extends TestCase {
+
+    public function test_unwrapFormattedNumber()
+    {
+        $htmlPieces = new HtmlPieces;
+
+        $this->assertEquals("1500000", $htmlPieces->unwrapFormattedNumber("1.5M"));
+        $this->assertEquals("1200", $htmlPieces->unwrapFormattedNumber("1.2K"));
+        $this->assertEquals("1.8", $htmlPieces->unwrapFormattedNumber("1.8"));
+        // $this->assertEquals($expected, $actual);
+    }
+
+}

--- a/tests/ImdbTest.php
+++ b/tests/ImdbTest.php
@@ -18,9 +18,9 @@ class ImdbTest extends TestCase {
         $this->assertEquals('2014', $film['year']);
         $this->assertEquals('vi1586278169', $film['trailer']["id"]);
         $this->assertEquals('https://www.imdb.com/video/vi1586278169', $film['trailer']["link"]);
-        $this->assertEquals('Cooper', $film['cast'][0]["character"]);
-        $this->assertEquals('Matthew McConaughey', $film['cast'][0]["actor"]);
-        $this->assertEquals('nm0000190', $film['cast'][0]["actor_id"]);
+        $this->assertContains($film['cast'][0]["character"], array('Cooper', 'Murph (Older)'));
+        $this->assertContains($film['cast'][0]["actor"], array('Matthew McConaughey', 'Ellen Burstyn'));
+        $this->assertContains($film['cast'][0]["actor_id"], array('nm0000190', 'nm0000995'));
     }
 
     public function testFilmBySearching()
@@ -34,9 +34,9 @@ class ImdbTest extends TestCase {
         $this->assertEquals('2014', $film['year']);
         $this->assertEquals('vi1586278169', $film['trailer']["id"]);
         $this->assertEquals('https://www.imdb.com/video/vi1586278169', $film['trailer']["link"]);
-        $this->assertEquals('Cooper', $film['cast'][0]["character"]);
-        $this->assertEquals('Matthew McConaughey', $film['cast'][0]["actor"]);
-        $this->assertEquals('nm0000190', $film['cast'][0]["actor_id"]);
+        $this->assertContains($film['cast'][0]["character"], array('Cooper', 'Murph (Older)'));
+        $this->assertContains($film['cast'][0]["actor"], array('Matthew McConaughey', 'Ellen Burstyn'));
+        $this->assertContains($film['cast'][0]["actor_id"], array('nm0000190', 'nm0000995'));
     }
 
     public function testFilmOptions()

--- a/tests/ImdbTest.php
+++ b/tests/ImdbTest.php
@@ -17,10 +17,10 @@ class ImdbTest extends TestCase {
         $this->assertEquals('2h 49min', $film['length']);
         $this->assertEquals('2014', $film['year']);
         $this->assertEquals('vi1586278169', $film['trailer']["id"]);
-        $this->assertEquals('https://www.imdb.com/videoplayer/vi1586278169', $film['trailer']["link"]);
-        $this->assertEquals('Murph (Older)', $film['cast'][0]["character"]);
-        $this->assertEquals('Ellen Burstyn', $film['cast'][0]["actor"]);
-        $this->assertEquals('nm0000995', $film['cast'][0]["actor_id"]);
+        $this->assertEquals('https://www.imdb.com/video/vi1586278169', $film['trailer']["link"]);
+        $this->assertEquals('Cooper', $film['cast'][0]["character"]);
+        $this->assertEquals('Matthew McConaughey', $film['cast'][0]["actor"]);
+        $this->assertEquals('nm0000190', $film['cast'][0]["actor_id"]);
     }
 
     public function testFilmBySearching()
@@ -33,10 +33,10 @@ class ImdbTest extends TestCase {
         $this->assertEquals('2h 49min', $film['length']);
         $this->assertEquals('2014', $film['year']);
         $this->assertEquals('vi1586278169', $film['trailer']["id"]);
-        $this->assertEquals('https://www.imdb.com/videoplayer/vi1586278169', $film['trailer']["link"]);
-        $this->assertEquals('Murph (Older)', $film['cast'][0]["character"]);
-        $this->assertEquals('Ellen Burstyn', $film['cast'][0]["actor"]);
-        $this->assertEquals('nm0000995', $film['cast'][0]["actor_id"]);
+        $this->assertEquals('https://www.imdb.com/video/vi1586278169', $film['trailer']["link"]);
+        $this->assertEquals('Cooper', $film['cast'][0]["character"]);
+        $this->assertEquals('Matthew McConaughey', $film['cast'][0]["actor"]);
+        $this->assertEquals('nm0000190', $film['cast'][0]["actor_id"]);
     }
 
     public function testFilmOptions()


### PR DESCRIPTION
## Patch strategy
The new IMDB site seems to be on a canary rollout - this means the old site is still active and has not been replaced fully yet.

To resolve this, I have 'patched' the pattern matches to detect BOTH the old and the new site.

## Pattern Matching Fixes
- Title
- Year
- Length
- Trailer
- Cast

## Fixes
- Detects TV shows and returns correct "Year" - `2014–2016`

Fixes #6 
