### PR TITLE
Urgent: Fixed bug: for php 7.3 & 7.4 support.

### DIFF
--- a/src/HtmlPieces.php
+++ b/src/HtmlPieces.php
@@ -10,9 +10,9 @@ namespace hmerritt;
 */
 class HtmlPieces
 {
-    public ?string $filmId;
+    public $filmId;
 
-    public function __construct(?string $filmId = null)
+    public function __construct(string $filmId = null)
     {
         $this->filmId = $filmId;
     }


### PR DESCRIPTION
I'm using this awesome php package but recently, the latest update broke php back word compatibility for 7.3 & 7.4

I've fixed it, and now it's working as intended :D

The change/fix is small:
```diff
class HtmlPieces
{
+    public $filmId;
-    public ?string $filmId;

+    public function __construct(string $filmId = null)
-    public function __construct(?string $filmId = null)
    {
        $this->filmId = $filmId;
    }

```

Please accept my PR and upgrade the package version.

Thanks in advance :D